### PR TITLE
Add instructions to install Grafana plugins on the README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,32 @@ services:
       - /path/to/grafana.ini:/opt/bitnami/grafana/conf/grafana.ini
 ```
 
+## Install plugins at initialization
+
+When you start the Grafana image, you can specify a comma, semi-colon or space separated list of plugins to install by setting the env. variable `GF_INSTALL_PLUGINS`.
+
+ * For docker-compose add the variable name and value under the application section:
+
+```yaml
+version: '2'
+
+services:
+  grafana:
+    image: bitnami/grafana:latest
+    environment:
+      - GF_INSTALL_PLUGINS=grafana-kubernetes-app,grafana-example-app
+    ports:
+      - '3000:3000'
+```
+
+ * For manual execution add a `-e` option with each variable and value:
+
+```bash
+$ docker run -d --name grafana -p 3000:3000 \
+    -e GF_INSTALL_PLUGINS=grafana-kubernetes-app,grafana-example-app \
+    bitnami/grafana:latest
+```
+
 # Logging
 
 The Bitnami grafana Docker image sends the container logs to the `stdout`. To view the logs:


### PR DESCRIPTION
**Description of the change**

This PR updates the README.md file adding the instructions to install plugins during the initialisation of the container.

- fixes https://github.com/bitnami/bitnami-docker-grafana/issues/2