### PR TITLE
docs: Add port to docker run commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Grafana is an open source, feature rich metrics dashboard and graph editor for G
 $ docker run -p 3000:3000 --name grafana bitnami/grafana:latest
 ```
 
+Head to http://localhost:3000/ and log in with the default username **admin** and the password **admin**. You will be asked to set a new password, afterwards.
+
 ## Why use Bitnami Images?
 
 * Bitnami closely tracks upstream source changes and promptly publishes new versions of this image using our automated systems.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Grafana is an open source, feature rich metrics dashboard and graph editor for G
 ## TL;DR
 
 ```console
-$ docker run --name grafana bitnami/grafana:latest
+$ docker run -p 3000:3000 --name grafana bitnami/grafana:latest
 ```
 
 ## Why use Bitnami Images?
@@ -79,7 +79,7 @@ $ docker network create grafana-network --driver bridge
 Use the `--network <NETWORK>` argument to the `docker run` command to attach the container to the `grafana-network` network.
 
 ```console
-$ docker run --name grafana-node1 --network grafana-network bitnami/grafana:latest
+$ docker run -p 3000:3000 --name grafana-node1 --network grafana-network bitnami/grafana:latest
 ```
 
 #### Step 3: Run another containers
@@ -222,7 +222,7 @@ $ docker rm -v grafana
 Re-create your container from the new image, [restoring your backup](#restoring-a-backup) if necessary.
 
 ```console
-$ docker run --name grafana bitnami/grafana:latest
+$ docker run -p 3000:3000 --name grafana bitnami/grafana:latest
 ```
 
 ## Notable Changes


### PR DESCRIPTION
**Description of the change**

This PR adds the `-p` flag to some snippets running `docker run`.

**Benefits**

I have seen some articles, courses, and tutorials running the `grafana/grafana` image directly with `docker run`. The specification of `-p 3000:3000` is a common pattern in all of them since manual `docker` executions are meant to target debugging/development actions when your next action is accessing the Grafana UI through a browser. Example found in a well-known training:

> To run Grafana on Docker on port `3000`, run:
>
> ```
> docker run -d -p 3000:3000 --name grafana grafana/grafana:7.0.0
> ```
>
> Head to ​http://\<machine-ip\>:3000/​ and log in with the default username ​`admin`​ and the password `​admin`

_**NOTE**: I would also mention how to log in Grafana in our **TL;DR** section, actually_

In order to have direct portability to this kind of online docs, I think it makes sense to export the port connection within the `docker run` command. Moreover, it also makes port `3000` explicit for new Grafana users not used to work with it.

**Possible drawbacks**

The `docker run` command won't work if a user is already running a service listening to this port.