### PR TITLE
[Bug] User Rights for `/opt/bitnami/grafana/data` and `/opt/bitnami/grafana/logs`

### DIFF
--- a/7/debian-10/Dockerfile
+++ b/7/debian-10/Dockerfile
@@ -16,10 +16,7 @@ RUN wget -nc -P /tmp/bitnami/pkg/cache/ https://downloads.bitnami.com/files/stac
 RUN apt-get update && apt-get upgrade -y && \
     rm -r /var/lib/apt/lists /var/cache/apt/archives
 RUN chmod g+rwX /opt/bitnami
-# Introduced a new USER Env variable
-ARG BITNAMI_UID=1001
-
-RUN mkdir -p /opt/bitnami/grafana/data/ /opt/bitnami/grafana/logs/ && chown "${BITNAMI_UID}:root" /opt/bitnami/grafana/data/ /opt/bitnami/grafana/logs/
+RUN mkdir -p /opt/bitnami/grafana/data/ /opt/bitnami/grafana/logs/ && chown -R 1001:root /opt/bitnami/grafana/data/ /opt/bitnami/grafana/logs/ && chmod g+rwX /opt/bitnami/grafana/data/ /opt/bitnami/grafana/logs/
 RUN mv /opt/bitnami/grafana/conf/sample.ini /opt/bitnami/grafana/conf/grafana.ini
 
 COPY rootfs /
@@ -31,5 +28,5 @@ ENV BITNAMI_APP_NAME="grafana" \
 EXPOSE 3000
 
 WORKDIR /opt/bitnami/grafana
-USER "${BITNAMI_UID}"
+USER 1001
 ENTRYPOINT [ "/run.sh" ]

--- a/7/debian-10/Dockerfile
+++ b/7/debian-10/Dockerfile
@@ -16,7 +16,10 @@ RUN wget -nc -P /tmp/bitnami/pkg/cache/ https://downloads.bitnami.com/files/stac
 RUN apt-get update && apt-get upgrade -y && \
     rm -r /var/lib/apt/lists /var/cache/apt/archives
 RUN chmod g+rwX /opt/bitnami
-RUN mkdir -p /opt/bitnami/grafana/data/ /opt/bitnami/grafana/logs/ && chmod g+rwX /opt/bitnami/grafana/data/ /opt/bitnami/grafana/logs/
+# Introduced a new USER Env variable
+ARG BITNAMI_UID=1001
+
+RUN mkdir -p /opt/bitnami/grafana/data/ /opt/bitnami/grafana/logs/ && chown "${BITNAMI_UID}:root" /opt/bitnami/grafana/data/ /opt/bitnami/grafana/logs/
 RUN mv /opt/bitnami/grafana/conf/sample.ini /opt/bitnami/grafana/conf/grafana.ini
 
 COPY rootfs /
@@ -28,5 +31,5 @@ ENV BITNAMI_APP_NAME="grafana" \
 EXPOSE 3000
 
 WORKDIR /opt/bitnami/grafana
-USER 1001
+USER "${BITNAMI_UID}"
 ENTRYPOINT [ "/run.sh" ]

--- a/7/debian-10/rootfs/grafana-plugins.sh
+++ b/7/debian-10/rootfs/grafana-plugins.sh
@@ -45,8 +45,7 @@ for plugin in "${grafana_plugin_list[@]}"; do
   "${grafana_install_plugin_command[@]}" "${grafana_install_plugin_args[@]}" "${plugin}"
 done
 
-chmod g+rwX /opt/bitnami/grafana/data/plugins
-chown -R 1001:1001 /opt/bitnami/grafana/data/plugins
+chmod a+rwX /opt/bitnami/grafana/data/plugins
 
 # The Grafana Helm chart mounts the data directory at "/opt/bitnami/grafana/data"
 # Therefore, all the plugins installed when building the image will be lost

--- a/7/debian-10/rootfs/grafana-plugins.sh
+++ b/7/debian-10/rootfs/grafana-plugins.sh
@@ -46,6 +46,7 @@ for plugin in "${grafana_plugin_list[@]}"; do
 done
 
 chmod g+rwX /opt/bitnami/grafana/data/plugins
+chown -R 1001:1001 /opt/bitnami/grafana/data/plugins
 
 # The Grafana Helm chart mounts the data directory at "/opt/bitnami/grafana/data"
 # Therefore, all the plugins installed when building the image will be lost

--- a/7/debian-10/rootfs/grafana-plugins.sh
+++ b/7/debian-10/rootfs/grafana-plugins.sh
@@ -45,7 +45,7 @@ for plugin in "${grafana_plugin_list[@]}"; do
   "${grafana_install_plugin_command[@]}" "${grafana_install_plugin_args[@]}" "${plugin}"
 done
 
-chmod a+rwX /opt/bitnami/grafana/data/plugins
+chmod g+rwX /opt/bitnami/grafana/data/plugins
 
 # The Grafana Helm chart mounts the data directory at "/opt/bitnami/grafana/data"
 # Therefore, all the plugins installed when building the image will be lost


### PR DESCRIPTION
Added the plugins under the uid `1001` instead of root. This should help with the operator issue.

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
