### PR TITLE
[fix #22] Fixed compatibility issues with grafana-operator

### DIFF
--- a/8/debian-10/rootfs/opt/bitnami/scripts/grafana/entrypoint.sh
+++ b/8/debian-10/rootfs/opt/bitnami/scripts/grafana/entrypoint.sh
@@ -26,7 +26,7 @@ function is_exec() {
 
 print_welcome_page
 
-if [[ "$1" = "/opt/bitnami/scripts/grafana/run.sh" ]]; then
+if [[ "$1" = "/opt/bitnami/scripts/grafana/run.sh" ]] || ! is_exec "$1"; then
     # This catches the error-code from libgrafana.sh for the immediate exit when the grafana-operator is used. And ensure that the exit code is kept silently.
     /opt/bitnami/scripts/grafana/setup.sh || GRAFANA_OPERATOR_IMMEDIATE_EXIT=$?
     if [[ "${GRAFANA_OPERATOR_IMMEDIATE_EXIT:-0}" -eq 255 ]]; then

--- a/8/debian-10/rootfs/opt/bitnami/scripts/grafana/postunpack.sh
+++ b/8/debian-10/rootfs/opt/bitnami/scripts/grafana/postunpack.sh
@@ -23,10 +23,16 @@ info "Creating system user"
 ensure_user_exists "$GRAFANA_DAEMON_USER" --group "$GRAFANA_DAEMON_GROUP" --system
 
 info "Configuring file permissions"
-for dir in "$(grafana_env_var_value PATHS_DATA)" "$(grafana_env_var_value PATHS_LOGS)" "$(grafana_env_var_value PATHS_PLUGINS)"; do
+for dir in  "$(grafana_env_var_value PATHS_DATA)" "$(grafana_env_var_value PATHS_LOGS)" "$(grafana_env_var_value PATHS_PLUGINS)" "$(grafana_env_var_value PATHS_PROVISIONING)"; do
     ensure_dir_exists "$dir"
     # Use grafana:root ownership for compatibility when running as a non-root user
     configure_permissions_ownership "$dir" -d "775" -f "664" -u "$GRAFANA_DAEMON_USER" -g "root"
+done
+
+# Ensure permissions to parent directories of configs
+# Used when replacing configs with symlinks for grafana-operator compatibility
+for dir in "$(grafana_env_var_value PATHS_CONFIG)" "$(grafana_env_var_value PATHS_DATA)" "$(grafana_env_var_value PATHS_LOGS)" "$(grafana_env_var_value PATHS_PROVISIONING)"; do
+    chmod 775 "$(dirname "$dir")"
 done
 
 # Install well-known plugins


### PR DESCRIPTION
**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->
Fixes setup code not running when CMD is overriden to a non-executable value.
In this case run.sh is still executed (with CMD value as arguments), but without first running setup.

Also fixes permission issues with setup code.
Setup code checks if operator compatible paths exist, if they do it removes the regular path and creates a symlink to operator mounts.
There were 2 issues:
- Missing permissions to delete content of `/opt/bitnami/grafana/conf/provisioning`
- Missing permissions to remove the config files/directories themselves (write bit on parent directory)

**Benefits**

Fixes regression that caused incompatibility with grafana operator

**Applicable issues**

- Fixes #22
